### PR TITLE
feat(useTrapTabKey): refactor and return two button refs

### DIFF
--- a/src/components/ConfirmationModal/index.tsx
+++ b/src/components/ConfirmationModal/index.tsx
@@ -22,7 +22,12 @@ export const ConfirmationModal = ({
 }: ConfirmationModalProps) => {
   const [ref] = useClickOutside(() => setOpen(false))
 
-  useTrapTabKey({ ref, setOpen })
+  const { firstButtonElementRef } = useTrapTabKey({ ref, setOpen })
+
+  const handleCancel = (event: React.MouseEvent) => {
+    event.stopPropagation()
+    toggleModal()
+  }
 
   return (
     <>
@@ -30,12 +35,7 @@ export const ConfirmationModal = ({
         <ConfirmationTitle>Are you sure?</ConfirmationTitle>
         <ConfirmationText>{text}</ConfirmationText>
         <ConfirmButton>Yes</ConfirmButton>
-        <CancelButton
-          onClick={(event) => {
-            event.stopPropagation()
-            toggleModal()
-          }}
-        >
+        <CancelButton onClick={handleCancel} ref={firstButtonElementRef}>
           No
         </CancelButton>
       </Modal>

--- a/src/components/EditModal/index.tsx
+++ b/src/components/EditModal/index.tsx
@@ -39,9 +39,17 @@ export const EditModal = ({
     /* Submit edited Task with new text */
   }
 
+  const handleCancel = (event: React.MouseEvent) => {
+    event.stopPropagation()
+    toggleModal()
+  }
+
   const [ref] = useClickOutside(() => setOpen(false))
 
-  useTrapTabKey({ ref, setOpen })
+  const { firstButtonElementRef, secondButtonElementRef } = useTrapTabKey({
+    ref,
+    setOpen,
+  })
 
   return (
     <>
@@ -50,10 +58,8 @@ export const EditModal = ({
           <EditTitle>Edit task</EditTitle>
           <EditCloseButton
             aria-label="Cancel edit"
-            onClick={(event) => {
-              event.stopPropagation()
-              toggleModal()
-            }}
+            onClick={handleCancel}
+            ref={firstButtonElementRef}
           >
             <EditClose aria-hidden="true" />
           </EditCloseButton>
@@ -72,11 +78,9 @@ export const EditModal = ({
             Edit
           </EditConfirmButton>
           <EditCancelButton
-            onClick={(event) => {
-              event.stopPropagation()
-              toggleModal()
-            }}
+            onClick={handleCancel}
             type="button"
+            ref={secondButtonElementRef}
           >
             Cancel
           </EditCancelButton>


### PR DESCRIPTION
Both button refs can be used to track if any of the cancel buttons were being pressed.

A general cleanup and refactoring has been made.