### PR TITLE
fix: stylelint script to lint all nested ts/tsx files

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "lint": "tsc --noEmit && eslint --fix --ext src/**/*.ts{,x}",
-    "lint:css": "stylelint src/**/*.ts{,x}",
+    "lint:css": "stylelint \"src/**/**.ts{,x}\"",
     "test:e2e": "BROWSER=none start-server-and-test start 3000 cy:run",
     "cy:run": "cypress run",
     "cy:open": "cypress open"


### PR DESCRIPTION
Fix stylelint not lint all nested ts files

**Example**: pages/Board/styles.ts

**Before**: no stylelint error
**After**:
```
src/pages/Board/styles.ts
 91:3  ✖  Unexpected duplicate "align-items"   declaration-block-no-duplicate-properties
```
https://github.com/stylelint/stylelint/issues/4846